### PR TITLE
TaskRouter calls optimisations

### DIFF
--- a/public/resources/functions/inqueue-callback.protected.js
+++ b/public/resources/functions/inqueue-callback.protected.js
@@ -356,7 +356,7 @@ exports.handler = function (context, event, callback) {
       async function main() {
         //  get taskSid based on callSid
         //  taskInfo = { "sid" : <taskSid>, "queueTargetName" : <taskQueueName>, "queueTargetSid" : <taskQueueSid> };
-        let taskInfo = await getTask(event.taskSid || event.callsid);
+        const taskInfo = await getTask(event.taskSid || event.callsid);
 
         //  cancel (update) the task given taskSid
         let taskSid = event.taskSid || getOrigTaskData(taskInfo.originalTaskData, 'sid', '');

--- a/public/resources/functions/inqueue-callback.protected.js
+++ b/public/resources/functions/inqueue-callback.protected.js
@@ -63,10 +63,6 @@ exports.handler = function (context, event, callback) {
 
   //  find the task given the callSid or the task sid - get TaskSid
   async function getTask(sid) {
-
-    if (sid.startsWith('CA')) {
-      console.log('inqueue-callback:getTask called with Call Sid')
-    }
     try {
       let result = await (sid.startsWith('CA') 
       ? client.taskrouter

--- a/public/resources/functions/inqueue-voicemail.protected.js
+++ b/public/resources/functions/inqueue-voicemail.protected.js
@@ -59,21 +59,25 @@ exports.handler = function (context, event, callback) {
   //  find the task given the callSid or the task Sid - get TaskSid
   async function getTask(sid) {
     try {
-      let result = await (sid.startsWith('CA') 
-      ? client.taskrouter
-      .workspaces(context.TWILIO_WORKSPACE_SID)
-      .tasks.list({
-        evaluateTaskAttributes: `call_sid= '${sid}'`,
-        limit: 20
-      }) 
-      : fetchTask = client.taskrouter
-      .workspaces(context.TWILIO_WORKSPACE_SID)
-      .tasks(sid).fetch())
-
-      let taskInfo = {
-        originalTaskData: Array.isArray(result) ? result[0] : result,
+      if (sid.startsWith('CA')) {
+        const result = await client.taskrouter
+          .workspaces(context.TWILIO_WORKSPACE_SID)
+          .tasks.list({
+            evaluateTaskAttributes: `call_sid= '${sid}'`,
+            limit: 20
+          });
+        return {
+          originalTaskData: result[0],
+        };
+      }
+      
+      const result = await client.taskrouter
+        .workspaces(context.TWILIO_WORKSPACE_SID)
+        .tasks(sid)
+        .fetch();
+      return {
+        originalTaskData: result,
       };
-      return taskInfo;
     } catch (error) {
       console.log('getTask error');
       handleError(error);

--- a/public/resources/functions/queue-menu.protected.js
+++ b/public/resources/functions/queue-menu.protected.js
@@ -383,7 +383,7 @@ exports.handler = async function(context, event, callback) {
         const gather = twiml.gather({
           input: 'dtmf',
           timeout: '1',
-          action: domain + '/queue-menu?mode=menuProcess'
+          action: domain + `/queue-menu?mode=menuProcess${event.taskSid ? '&taskSid=' + event.taskSid : ''}`
         });
         gather.say(sayOptions, message);
         gather.play(domain + '/assets/guitar_music.mp3');
@@ -391,7 +391,7 @@ exports.handler = async function(context, event, callback) {
         callback(null, twiml);
       } else {
         twiml.say(sayOptions, 'I did not understand your selection.');
-        twiml.redirect(domain + '/queue-menu?mode=main&skipGreeting=true');
+        twiml.redirect(domain + `/queue-menu?mode=main&skipGreeting=true${event.taskSid ? '&taskSid=' + event.taskSid : ''}`);
         callback(null, twiml);
       }
 
@@ -403,30 +403,30 @@ exports.handler = async function(context, event, callback) {
         case '1':
           //  stay in queue
           //twiml.say(sayOptions, 'Please wait for the next available agent');
-          twiml.redirect(domain + '/queue-menu?mode=main&skipGreeting=true');
+          twiml.redirect(domain + `/queue-menu?mode=main&skipGreeting=true${event.taskSid ? '&taskSid=' + event.taskSid : ''}`);
           callback(null, twiml);
           break;
         //  request a callback
         case '2':
-          twiml.redirect(domain + '/inqueue-callback?mode=main');
+          twiml.redirect(domain + `/inqueue-callback?mode=main${event.taskSid ? '&taskSid=' + event.taskSid : ''}`);
           callback(null, twiml);
           break;
         //  leave a voicemail
         case '3':
-          twiml.redirect(domain + '/inqueue-voicemail?mode=pre-process');
+          twiml.redirect(domain + `/inqueue-voicemail?mode=pre-process${event.taskSid ? '&taskSid=' + event.taskSid : ''}`);
           callback(null, twiml);
           break;
 
         // listen options menu again
         case '*':
-          twiml.redirect(domain + '/queue-menu?mode=mainProcess&Digits=1');
+          twiml.redirect(domain + `/queue-menu?mode=mainProcess&Digits=1${event.taskSid ? '&taskSid=' + event.taskSid : ''}`);
           callback(null, twiml);
           break;
 
         //  listen to menu again
         default:
           twiml.say(sayOptions, 'I did not understand your selection.');
-          twiml.redirect(domain + '/queue-menu?mode=mainProcess&Digits=1');
+          twiml.redirect(domain + `/queue-menu?mode=mainProcess&Digits=1${event.taskSid ? '&taskSid=' + event.taskSid : ''}`);
           callback(null, twiml);
           break;
       }

--- a/public/resources/functions/queue-menu.protected.js
+++ b/public/resources/functions/queue-menu.protected.js
@@ -80,35 +80,6 @@ exports.handler = async function(context, event, callback) {
     }
   }
 
-  //  retrieve workflow SID give CallSid using the TaskRouter API
-  async function getWorkFlow(callSid) {
-    return client.taskrouter
-      .workspaces(context.TWILIO_WORKSPACE_SID)
-      .tasks.list({
-        evaluateTaskAttributes: `call_sid= '${callSid}'`,
-        limit: 20
-      })
-      .then(tasks => {
-        res = {
-          status: 'success',
-          topic: 'getWorkFlow',
-          action: 'getWorkFlow',
-          workflowSid: tasks[0].workflowSid,
-          data: tasks
-        };
-        return res;
-      })
-      .catch(error => {
-        res = {
-          status: 'error',
-          topic: 'getWorkFlow',
-          action: 'getWorkFlow',
-          data: error
-        };
-        return res;
-      });
-  }
-
   //  retrieve workflow cummulative statistics for Estimated wait time
   async function getWorkflowCummStats(workflowSid) {
     return client.taskrouter

--- a/public/resources/functions/queue-menu.protected.js
+++ b/public/resources/functions/queue-menu.protected.js
@@ -115,7 +115,7 @@ exports.handler = async function(context, event, callback) {
    * @param {string} sid Call Sid or Task Sid 
    * @returns {Promise} Promise Object with Task Resource 
    */
-  async function getTask(sid) {
+  function getTask(sid) {
     let fetchTask;
     if (sid.startsWith('CA')) {
       fetchTask = client.taskrouter

--- a/public/resources/functions/queue-menu.protected.js
+++ b/public/resources/functions/queue-menu.protected.js
@@ -387,7 +387,7 @@ exports.handler = async function(context, event, callback) {
         });
         gather.say(sayOptions, message);
         gather.play(domain + '/assets/guitar_music.mp3');
-
+        twiml.redirect(domain + `/queue-menu?mode=main${event.taskSid ? '&taskSid=' + event.taskSid : ''}`)
         callback(null, twiml);
       } else {
         twiml.say(sayOptions, 'I did not understand your selection.');


### PR DESCRIPTION
The aim of this PR is to optimise the call made to Twilio APIs and specifically to TaskRouter `evaluateTaskAttributes` endpoint. 

The code is currently using this endpoint to fetch the Task SID from the Call SID and provide waiting time and position in the queue prompt during the call. This endpoint is called several times during the flow. 

Fix #19 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
